### PR TITLE
Try out the new cache.yml and 'template' key

### DIFF
--- a/.buildkite/cache.yml
+++ b/.buildkite/cache.yml
@@ -1,0 +1,7 @@
+caches:
+  - id: "ruby"
+    template: "ruby"
+  - id: "docker"
+    key: '{{ id }}-{{ agent.os }}-{{ agent.arch }}-{{ checksum ".buildkite/Dockerfile.build" }}'
+    fallback_keys: ["{{ id }}-{{ agent.os }}-{{ agent.arch }}-"]
+    paths: ["vendor/containers"]

--- a/.buildkite/pipeline.nsc.yml
+++ b/.buildkite/pipeline.nsc.yml
@@ -2,16 +2,9 @@ agents:
   queue: nsc-artifact-storage
 
 common:
-  - zipstash_pkg_plugin: &zstash-ruby
-      buildkite/zstash#main:
-        id: "ruby-nsc"
-        key: '{{ id }}-{{ agent.os }}-{{ agent.arch }}-{{ checksum "Gemfile.lock" }}'
-        fallback_keys: |
-          {{ id }}-{{ agent.os }}-{{ agent.arch }}-
-        paths: |
-          vendor/bundle
-        bucket-url: $BUCKET_URL
-        store: "nsc"
+  - buildkite_cache: &buildkite-cache
+      "buildkite/zstash":
+        ids: "ruby"
 
 env:
   BUNDLE_FROZEN: true # Don't allow lockfile to mutate during CI
@@ -35,18 +28,18 @@ steps:
         command:
           - "bundle install --quiet"
         plugins:
-          - *zstash-ruby
+          - *buildkite-cache
       - label: ":rspec: Run system specs"
         command:
           - "bundle exec rspec spec/system"
         depends_on:
           - "install_dependencies"
         plugins:
-          - *zstash-ruby
+          - *buildkite-cache
       - label: ":rspec: Run model specs"
         command:
           - "bundle exec rspec spec/models"
         depends_on:
           - "install_dependencies"
         plugins:
-          - *zstash-ruby
+          - *buildkite-cache

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,24 +2,12 @@ common:
   - aws-assume-role_plugin: &aws-assume-role
       aws-assume-role-with-web-identity#v1.1.0:
         role-arn: ${CACHE_ROLE}
-  - zipstash_pkg_plugin: &zstash-ruby
-      buildkite/zstash#v0.1.0:
-        id: "ruby"
-        key: '{{ id }}-{{ agent.os }}-{{ agent.arch }}-{{ checksum "Gemfile.lock" }}'
-        fallback_keys: |
-          {{ id }}-{{ agent.os }}-{{ agent.arch }}-
-        paths: |
-          vendor/bundle
-        bucket-url: $BUCKET_URL
-  - zipstash_docker_plugin: &zstash-docker
-      buildkite/zstash#v0.1.0:
-        id: "docker"
-        key: '{{ id }}-{{ agent.os }}-{{ agent.arch }}-{{ checksum ".buildkite/Dockerfile.build" }}'
-        fallback_keys: |
-          {{ id }}-{{ agent.os }}-{{ agent.arch }}-
-        paths: |
-          vendor/containers
-        bucket-url: $BUCKET_URL
+  - buildkite_cache_ruby: &buildkite-cache-ruby-and-docker
+      "buildkite/zstash":
+        ids: "ruby,docker"
+  - buildkite_cache_docker: &buildkite-cache-docker
+      "buildkite/zstash":
+        ids: "docker"
   -  docker-compose_plugin: &docker-compose
       docker-compose#v5.10.0:
         config: .buildkite/docker-compose.yaml
@@ -68,7 +56,7 @@ steps:
         key: "build_base_image"
         plugins:
           - *aws-assume-role
-          - *zstash-docker
+          - *buildkite-cache-docker
           - *docker-compose-build
       - label: ":rubygems: Install dependencies"
         key: "install_dependencies"
@@ -80,11 +68,10 @@ steps:
           - "bundle config --local quiet true"
           - "bundle install"
         plugins:
+          - *aws-assume-role
+          - *buildkite-cache-ruby-and-docker
           - *docker-compose-build
           - *docker-compose
-          - *aws-assume-role
-          - *zstash-docker
-          - *zstash-ruby
       - label: ":rspec: Run system specs"
         command:
           - "bundle config --local path vendor/bundle"
@@ -92,11 +79,10 @@ steps:
         depends_on:
           - "install_dependencies"
         plugins:
+          - *aws-assume-role
+          - *buildkite-cache-ruby-and-docker
           - *docker-compose-build
           - *docker-compose
-          - *aws-assume-role
-          - *zstash-docker
-          - *zstash-ruby
       - label: ":rspec: Run model specs"
         command:
           - "bundle config --local path vendor/bundle"
@@ -104,8 +90,7 @@ steps:
         depends_on:
           - "install_dependencies"
         plugins:
+          - *aws-assume-role
+          - *buildkite-cache-ruby-and-docker
           - *docker-compose-build
           - *docker-compose
-          - *aws-assume-role
-          - *zstash-docker
-          - *zstash-ruby


### PR DESCRIPTION
Uses `zstashv0.3.1` and latest `buildkite/zstash` plugin version.

This should work for:
* `buildkite/kitesocial`
* `buildkite/kitesocial-namespace`

But not for: `buildkite/kitesocial-base-image` (because that pipeline file doesn't exist yet)