### PR TITLE
Publish Base Image (with zstsah and Ruby) to NSCR

### DIFF
--- a/.buildkite/Dockerfile.build
+++ b/.buildkite/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM buildkite/hosted-agent-base-images:ubuntu-jammy
 RUN apt-get update && apt-get install -y \
   git \
   jq \

--- a/.buildkite/pipeline.base-image.yml
+++ b/.buildkite/pipeline.base-image.yml
@@ -1,0 +1,16 @@
+steps:
+  - label: ":docker: Create base image"
+    command: |
+      export REGISTRY="$(nsc workspace describe -o json -k registry_url)"
+      export SERVICE="base"
+      export DOCKER_REPOSITORY="$${REGISTRY}/$${SERVICE}:latest"
+
+      docker buildx build \
+        --no-cache \
+        --file .buildkite/Dockerfile.build \
+        --platform linux/amd64,linux/arm64 \
+        --tag "$${DOCKER_REPOSITORY}" \
+        --progress plain \
+        --push .
+
+      buildkite-agent annotate --style "success" ":rocket: Image pushed to $${DOCKER_REPOSITORY} :rocket:"


### PR DESCRIPTION
This should work for `buildkite/kitesocial-base-image` (a new pipeline to run this additional pipeline file).

This won't work for:
* `buildkite/kitesocial`
* `buildkite/kitesocial-namespace`

Because the pipeline files for these are not up to date with latest Hosted Agents base image versions (running the latest `zstash` CLI tool)